### PR TITLE
Support for symbols

### DIFF
--- a/lib/json/canonicalization.rb
+++ b/lib/json/canonicalization.rb
@@ -61,13 +61,21 @@ class Numeric
   end
 end
 
+def encode_key(k)
+  case k
+  when String
+    return k.encode(Encoding::UTF_16)
+  end
+  k
+end
+
 class Hash
   # Output JSON with keys sorted lexicographically
   # @return [String]
   def to_json_c14n
     "{" + self.
       keys.
-      sort_by {|k| k.encode(Encoding::UTF_16)}.
+      sort_by {|k| encode_key(k)}.
       map {|k| k.to_json_c14n + ':' + self[k].to_json_c14n}
       .join(',') +
     '}'
@@ -81,3 +89,12 @@ class String
     self.to_json
   end
 end
+
+class Symbol
+  # Output JSON with control characters escaped
+  # @return [String]
+  def to_json_c14n
+    self.to_json
+  end
+end
+

--- a/spec/c14n_spec.rb
+++ b/spec/c14n_spec.rb
@@ -9,3 +9,10 @@ describe "conversions" do
     end
   end
 end
+
+describe "special cases for hash keys" do
+    it "handles hash defined with symbols" do
+      data = { a: [{b:"b"}] }
+      expect(data.to_json_c14n).to eq "{\"a\":[{\"b\":\"b\"}]}"
+    end
+end


### PR DESCRIPTION
Hello @gkellogg, thanks for you work.

I thought it would be handy the support for symbol, in order to be able to call `to_json_c14n` on a hash defined with symbols, giving me a stable string representation of such hash.

Thanks 